### PR TITLE
feat: manifest support

### DIFF
--- a/main.py
+++ b/main.py
@@ -81,6 +81,14 @@ class Plugin:
         decky.logger.debug("Executing: get_ludusavi_config()")
         return await self.ludusavi.get_config()
 
+    async def get_game_name_by_appid_from_manifest(self, appId: str):
+        decky.logger.debug("Executing: get_game_name_by_appid_from_manifest('%s')", appId)
+        return await self.ludusavi.get_game_name_by_appid(appId)
+
+    async def update_manifest(self, force: bool): 
+        decky.logger.info("Executing: update_manifest('%s')", force)
+        return await self.ludusavi.update_manifest(force)
+
     # Asyncio-compatible long-running code, executed in a task when the plugin is loaded
     async def _main(self):
         self.ludusavi = Ludusavi(

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "homepage": "https://github.com/GedasFX/decky-ludusavi#readme",
   "devDependencies": {
     "@decky/rollup": "^1.0.1",
-    "@decky/ui": "^4.9.2",
+    "@decky/ui": "^4.10.2",
     "@types/react": "18.3.3",
     "@types/react-dom": "18.3.0",
     "@types/webpack": "^5.28.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,8 +19,8 @@ importers:
         specifier: ^1.0.1
         version: 1.0.1
       '@decky/ui':
-        specifier: ^4.9.2
-        version: 4.9.2
+        specifier: ^4.10.2
+        version: 4.10.2
       '@types/react':
         specifier: 18.3.3
         version: 18.3.3
@@ -48,8 +48,8 @@ packages:
   '@decky/rollup@1.0.1':
     resolution: {integrity: sha512-dx1VJwD7ul14PA/aZvOwAfY/GujHzqZJ+MFb4OIUVi63/z4KWMSuZrK6QWo0S4LrNW3RzB3ua6LT0WcJaNY9gw==}
 
-  '@decky/ui@4.9.2':
-    resolution: {integrity: sha512-3cBmBuyctdMhAyE4MtMgK6oEMrjiW2BiMLfSJ/m6qxukRnb2PpvTTyYurnT83vZGVDeygcmcmWjs2nFzGlyLvQ==}
+  '@decky/ui@4.10.2':
+    resolution: {integrity: sha512-dfY/OEI/rhG4d3Tvx4Y3TLmBrJ+nAm2RTbkoOJ3VAglql3Lu7RY2ixeDFbs21ZWWzWh/C+9dAQKjQ4lx4d1f2g==}
 
   '@isaacs/cliui@8.0.2':
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
@@ -933,7 +933,7 @@ snapshots:
       tslib: 2.8.1
       typescript: 5.8.2
 
-  '@decky/ui@4.9.2': {}
+  '@decky/ui@4.10.2': {}
 
   '@isaacs/cliui@8.0.2':
     dependencies:

--- a/py_modules/ludusavi.py
+++ b/py_modules/ludusavi.py
@@ -77,6 +77,20 @@ class Ludusavi:
             ["config", "show"],
         )
 
+    async def get_game_name_by_appid(self, appId: str):
+        return await self._run_command(
+            ["find", "--steam-id", appId]
+        )
+
+    async def update_manifest(self, force: bool = False):
+
+        argv = ["manifest", "update"]
+
+        if force:
+            argv.append("--force")
+
+        return await self._run_command(argv, None, False)
+
     async def _run_command(
         self, cmd: list[str], event: str | None = None, api_mode: bool = True
     ):

--- a/src/components/sidebar/LudusaviManifestUpdatePanel.tsx
+++ b/src/components/sidebar/LudusaviManifestUpdatePanel.tsx
@@ -1,0 +1,42 @@
+import { PanelSection, PanelSectionRow, ToggleField, ButtonItem } from "@decky/ui"
+import appState, { PersistentState, setAppState, useAppState, } from "../../util/state";
+import { setConfig, updateManifest } from "../../util/backend";
+import { useCallback, useState } from "react";
+import DeckyStoreButton from "../other/DeckyStoreButton";
+import { MdSystemUpdateAlt } from "react-icons/md";
+import { toaster } from "@decky/api";
+
+export default function LudusaviManifestUpdatePanel() {
+    const { manifest_force_update } = useAppState();
+    const handleConfigChange = useCallback((key: keyof PersistentState, value: boolean): void => {
+        setAppState(key, value);
+        setConfig(key, value);
+    }, []);
+    const [updating, setUpdating] = useState(false);
+    return (
+        <PanelSection title="Manifest">
+            <PanelSectionRow>
+                <ToggleField
+                    label="Force Update"
+                    checked={manifest_force_update}
+                    onChange={(e) => handleConfigChange("manifest_force_update", e)}
+                />
+                <ButtonItem
+                    onClick={() => {
+                        setUpdating(true);
+                        updateManifest(manifest_force_update)
+                            .then(() => {
+                                toaster.toast({ title: "Decky Ludusavi", body: `Ludusavi Manifest updated successful. Restarting plugin...` });
+                                appState.initialize();
+                            })
+                            .finally(() => setUpdating(false))
+                    }}
+                    layout="below"
+                    disabled={updating}
+                >
+                    <DeckyStoreButton icon={<MdSystemUpdateAlt />}>Update Manifest</DeckyStoreButton>
+                </ButtonItem>
+            </PanelSectionRow>
+        </PanelSection>
+    );
+}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -7,6 +7,7 @@ import ConfigurationPanel from "./components/sidebar/ConfigurationPanel";
 import { GameConfigurationPanel } from "./components/sidebar/GameConfigurationPanel";
 import { registerDependencies } from "./util/registrations";
 import OtherPanel from "./components/sidebar/OtherPanel";
+import LudusaviManifestUpdatePanel from "./components/sidebar/LudusaviManifestUpdatePanel";
 
 const Content: FC = () => {
   const { ludusavi_enabled } = useAppState();
@@ -20,6 +21,7 @@ const Content: FC = () => {
       <GameConfigurationPanel />
       <ConfigurationPanel />
       <OtherPanel />
+      <LudusaviManifestUpdatePanel />
       <LudusaviVersionPanel />
     </>
   );

--- a/src/util/backend.ts
+++ b/src/util/backend.ts
@@ -1,5 +1,5 @@
 import { addEventListener, call, removeEventListener } from "@decky/api";
-import { GameInfo, PersistentState } from "./state";
+import { GameInfo, PersistentState, GameNameFindResult } from "./state";
 
 export const getLudusaviVersion = () => call<[], { bin_path?: string, version: string }>("get_ludusavi_version");
 export const installLudusavi = () => asyncHandler<{ error?: unknown }>(() => call("install_ludusavi"), "install_ludusavi_complete");
@@ -21,6 +21,10 @@ export const getGameConfig = (key: string) => call<[string], GameInfo>("get_game
 export const setGameConfig = (key: string, value: GameInfo) => call<[string, GameInfo]>("set_game_config", key, value);
 
 export const getPluginLogs = () => call<[], string[]>("get_plugin_logs");
+
+export const getGameNameFormManifest = (appId: string) => call<[string], GameNameFindResult>("get_game_name_by_appid_from_manifest", appId);
+
+export const updateManifest = (force: boolean) => call<[boolean], void>("update_manifest", force);
 
 
 const asyncHandler = <TResult>(func: () => Promise<void>, event: string) => {

--- a/src/util/state.ts
+++ b/src/util/state.ts
@@ -2,6 +2,14 @@ import { useEffect, useState } from "react";
 import { getConfig, getLudusaviVersion, setConfig, setGameConfig } from "./backend";
 import { toaster } from "@decky/api";
 
+export interface GameNameFindResult {
+  games: {
+    [key: string]: {
+      score: number
+    }
+  }
+}
+
 export interface GameInfo {
   name: string;
   alias: string;
@@ -14,6 +22,8 @@ export type PersistentState = {
   auto_backup_new_games: boolean;
   auto_backup_toast_enabled: boolean;
 
+  manifest_force_update: boolean;
+
   recent_games: string[];
 }
 
@@ -25,6 +35,8 @@ export type State = {
   ludusavi_version: string;
 
   game_info?: GameInfo;
+
+  manifest_force_update: boolean;
 
   recent_games_selected?: string; // While its local state, dropdown gets unmounted when popup appears, so needs to be global state
 } & PersistentState;
@@ -39,6 +51,7 @@ class AppState {
     auto_backup_enabled: false,
     auto_backup_new_games: false,
     auto_backup_toast_enabled: false,
+    manifest_force_update: false,
     recent_games: [],
   };
 
@@ -54,6 +67,16 @@ class AppState {
     this.setState("auto_backup_enabled", await getConfig("auto_backup_enabled"));
     this.setState("auto_backup_new_games", await getConfig("auto_backup_new_games"));
     this.setState("auto_backup_toast_enabled", await getConfig("auto_backup_toast_enabled"));
+    this.setState("manifest_force_update", await getConfig("manifest_force_update"));
+  }
+
+  private async initializeManifestForceUpdate() {
+    const force = await getConfig("auto_backup_new_games");
+    if (force) {
+      this.setState("auto_backup_new_games", true);
+    } else {
+      this.setState("auto_backup_new_games", false);
+    }
   }
 
   private async initializeVersion() {

--- a/src/util/steamUtil.ts
+++ b/src/util/steamUtil.ts
@@ -1,12 +1,19 @@
-declare const appStore : any;
+import { getGameNameFormManifest } from "./backend"
+
+declare const appStore: any;
 export const resolveGameName = async (appId: number) => {
-    const [launchOptions, appOverview] = await Promise.all([
+    const [launchOptions, appOverview, manifest] = await Promise.all([
         SteamClient.Apps.GetLaunchOptionsForApp(appId),
-        appStore.GetAppOverviewByAppID(appId)
+        appStore.GetAppOverviewByAppID(appId),
+        getGameNameFormManifest(appId.toString())
     ]);
-    
-    const steamGameName = launchOptions?.strGameName;
+
+    const manifestName = manifest.games ? Object.keys(manifest.games)[0] : ''
+
+    console.log('manifestName', manifest, manifestName)
+
+    const steamGameName = manifestName ?? launchOptions?.strGameName;
     const nonSteamGameName = appOverview?.display_name;
-    
+
     return steamGameName ?? nonSteamGameName;
 }


### PR DESCRIPTION
1. support get game name from manifest by appid.
   eg: [Stellar Blade](https://store.steampowered.com/app/3489700/)
   the steam name is Stellar Blade™, but the manifest is Stellar Blade.Now can find the game name from the manifest file.
2. support update manifest from sidebar.