### PR TITLE
Normalize game name in ConfigureAliasModal

### DIFF
--- a/main.py
+++ b/main.py
@@ -38,6 +38,11 @@ class Plugin:
         decky.logger.debug("Executing: backup_game('%s')", game_name)
         asyncio.create_task(self.ludusavi.backup_game_async(game_name))
 
+    async def normalize_game_name(self, game_name: str):
+        decky.logger.debug("Executing: normalize_game_name('%s')", game_name)
+        result = await asyncio.create_task(self.ludusavi.normalize_game_name_async(game_name))
+        return result
+
     async def restore_game(
         self, game_name: str, backup_id: str, preview: bool, api_mode: bool
     ):

--- a/py_modules/ludusavi.py
+++ b/py_modules/ludusavi.py
@@ -77,6 +77,13 @@ class Ludusavi:
             ["config", "show"],
         )
 
+    async def normalize_game_name_async(self, game_name: str):
+        return await self._run_command(
+            ["find", "--normalized", game_name],
+            "normalize_game_name_complete",
+            api_mode=False,
+        )
+
     async def _run_command(
         self, cmd: list[str], event: str | None = None, api_mode: bool = True
     ):

--- a/src/util/backend.ts
+++ b/src/util/backend.ts
@@ -7,6 +7,7 @@ export const installLudusavi = () => asyncHandler<{ error?: unknown }>(() => cal
 export const backup = (gameName: string) => asyncHandler<LudusaviBackupResponse>(() => call("backup_game", gameName), "backup_game_complete");
 export const restore = (gameName: string, backupId: string) => asyncHandler<LudusaviBackupResponse>(() => call("restore_game", gameName, backupId, false, true), "restore_game_complete");
 export const restorePreview = (gameName: string, backupId: string) => asyncHandler<string>(() => call("restore_game", gameName, backupId, true, false), "restore_game_complete");
+export const normalizeGameName = (gameName: string) => asyncHandler<string>(() => call("normalize_game_name", gameName), "normalize_game_name_complete");
 
 export const getGameBackups = (gameName: string) => call<[string], LudusaviBackupListResponse>("get_game_backups", gameName);
 


### PR DESCRIPTION
Adding a middle button to the configure alias modal to normalize game name using Ludusavi find --normalized

Use case : Dave The Diver will not work, the exact alias needs to be "Dave the Diver"

Ex: 
The game name is set/imported as Dave The Diver. Hit the middle button "Find in manifest":
![image](https://github.com/user-attachments/assets/3bce75df-69de-42d1-bc14-556730a50349)

Shows a successful toast message:
![image](https://github.com/user-attachments/assets/e714e273-1557-4475-a607-234858625e11)

Manually opening the modal back up to confirm it worked: (optional)
![image](https://github.com/user-attachments/assets/76174e6a-9d1f-44e7-b7c1-c906774908e8)


Here is an example of what the toast will show when the game cannot be found, the original value would remain unchanged.
![image](https://github.com/user-attachments/assets/d915bebc-edff-4112-b526-982b7f630e30)

![image](https://github.com/user-attachments/assets/703110be-a8c4-4a1a-913e-3eaeac93d033)

The confirm button would still maintain its original functionality.